### PR TITLE
Replace yt-dlp with JS YouTube extraction and add PDF support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "openai": "^5.19.1",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
+        "pdf-parse": "^1.1.1",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -71,6 +72,7 @@
         "vaul": "^1.1.2",
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
+        "youtube-transcript": "^1.2.1",
         "zod": "^3.24.2",
         "zod-validation-error": "^3.4.0"
       },
@@ -85,6 +87,7 @@
         "@types/node": "20.16.11",
         "@types/passport": "^1.0.16",
         "@types/passport-local": "^1.0.38",
+        "@types/pdf-parse": "^1.1.5",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@types/ws": "^8.5.13",
@@ -3514,6 +3517,16 @@
         "@types/passport": "*"
       }
     },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.11.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
@@ -6260,6 +6273,12 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
@@ -6475,6 +6494,28 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/pg": {
       "version": "8.13.1",
@@ -9111,6 +9152,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/youtube-transcript": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/youtube-transcript/-/youtube-transcript-1.2.1.tgz",
+      "integrity": "sha512-TvEGkBaajKw+B6y91ziLuBLsa5cawgowou+Bk0ciGpjELDfAzSzTGXaZmeSSkUeknCPpEr/WGApOHDwV7V+Y9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "openai": "^5.19.1",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
+    "pdf-parse": "^1.1.1",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -73,6 +74,7 @@
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
+    "youtube-transcript": "^1.2.1",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },
@@ -87,6 +89,7 @@
     "@types/node": "20.16.11",
     "@types/passport": "^1.0.16",
     "@types/passport-local": "^1.0.38",
+    "@types/pdf-parse": "^1.1.5",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",

--- a/server/services/contentExtractor.ts
+++ b/server/services/contentExtractor.ts
@@ -1,7 +1,5 @@
-import { exec } from "child_process";
-import { promisify } from "util";
-
-const execAsync = promisify(exec);
+import { YoutubeTranscript } from "youtube-transcript";
+import pdfParse from "pdf-parse";
 
 export class ContentExtractor {
   static async extractFromUrl(url: string): Promise<{
@@ -11,16 +9,18 @@ export class ContentExtractor {
   }> {
     try {
       const urlObj = new URL(url);
-      
-      // YouTube detection
-      if (urlObj.hostname.includes('youtube.com') || urlObj.hostname.includes('youtu.be')) {
+
+      if (urlObj.hostname.includes("youtube.com") || urlObj.hostname.includes("youtu.be")) {
         return await this.extractYouTubeTranscript(url);
       }
-      
-      // Web page extraction
+
+      if (urlObj.pathname.toLowerCase().endsWith(".pdf")) {
+        return await this.extractPdfContent(url);
+      }
+
       return await this.extractWebContent(url);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`Failed to extract content: ${errorMessage}`);
     }
   }
@@ -31,75 +31,47 @@ export class ContentExtractor {
     type: string;
   }> {
     try {
-      // Extract video ID from URL
       const videoId = this.extractYouTubeId(url);
       if (!videoId) {
-        throw new Error('Invalid YouTube URL');
+        throw new Error("Invalid YouTube URL");
       }
 
-      // First, try to get video info and title
-      const infoCommand = `yt-dlp --print "%(title)s" "${url}"`;
-      let title = 'YouTube Video';
-      
+      let title = "YouTube Video";
+      let pageHtml: string | null = null;
       try {
-        const { stdout: titleOutput } = await execAsync(infoCommand);
-        title = titleOutput.trim() || 'YouTube Video';
-      } catch (titleError) {
-        console.warn('Failed to get video title, using default');
+        const res = await fetch(`https://www.youtube.com/watch?v=${videoId}`);
+        pageHtml = await res.text();
+        const titleMatch = pageHtml.match(/<title>([^<]+)<\/title>/i);
+        if (titleMatch) {
+          title = titleMatch[1].replace(" - YouTube", "").trim();
+        }
+      } catch (pageError) {
+        console.warn("Failed to fetch video page", pageError);
       }
 
-      // Try to get subtitles with a simpler approach
-      const subsCommand = `yt-dlp --write-subs --sub-lang en --skip-download --sub-format vtt --output "/tmp/yt_%(id)s.%(ext)s" "${url}"`;
-      
       try {
-        await execAsync(subsCommand);
-        
-        // Try to read the subtitle file
-        const vttFiles = await execAsync(`find /tmp -name "yt_${videoId}.en.vtt" -type f`);
-        
-        if (vttFiles.stdout.trim()) {
-          const vttFile = vttFiles.stdout.trim();
-          const { stdout: vttContent } = await execAsync(`cat "${vttFile}"`);
-          
-          // Clean up the file
-          await execAsync(`rm -f "${vttFile}"`);
-          
-          // Clean VTT content to plain text
-          const content = this.cleanVTTContent(vttContent);
-          
-          if (content.length > 50) { // Only accept if we got substantial content
-            return {
-              title,
-              content,
-              type: 'youtube'
-            };
+        const transcript = await YoutubeTranscript.fetchTranscript(videoId);
+        const content = transcript.map(t => t.text).join(" ");
+        if (content.trim().length > 50) {
+          return { title, content, type: "youtube" };
+        }
+      } catch (transcriptError) {
+        console.warn("Transcript fetch failed:", transcriptError);
+      }
+
+      if (pageHtml) {
+        const descMatch = pageHtml.match(/"shortDescription":"([^"]*)"/);
+        if (descMatch) {
+          const description = descMatch[1].replace(/\n/g, " ");
+          if (description.trim().length > 50) {
+            return { title, content: description.trim().substring(0, 5000), type: "youtube" };
           }
         }
-      } catch (subsError) {
-        console.warn('Subtitle extraction failed:', subsError);
       }
 
-      // Fallback: extract description if no subtitles available
-      try {
-        const descCommand = `yt-dlp --print "%(description)s" "${url}"`;
-        const { stdout: description } = await execAsync(descCommand);
-        
-        if (description && description.trim().length > 50) {
-          return {
-            title,
-            content: description.trim().substring(0, 5000), // Limit description length
-            type: 'youtube'
-          };
-        }
-      } catch (descError) {
-        console.warn('Description extraction failed:', descError);
-      }
-
-      // If everything fails, return basic info
-      throw new Error('No transcript or description available for this video. Some videos may not have subtitles or accessible content.');
-      
+      throw new Error("No transcript or description available for this video. Some videos may not have subtitles or accessible content.");
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`YouTube extraction failed: ${errorMessage}`);
     }
   }
@@ -107,23 +79,28 @@ export class ContentExtractor {
   private static extractYouTubeId(url: string): string | null {
     const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
     const match = url.match(regExp);
-    return (match && match[2].length === 11) ? match[2] : null;
+    return match && match[2].length === 11 ? match[2] : null;
   }
 
-  private static cleanVTTContent(vttContent: string): string {
-    // Remove VTT headers and timestamps
-    return vttContent
-      .split('\n')
-      .filter(line => 
-        !line.startsWith('WEBVTT') && 
-        !line.match(/^\d{2}:\d{2}:\d{2}\.\d{3}/) &&
-        !line.includes('-->') &&
-        line.trim() !== ''
-      )
-      .join(' ')
-      .replace(/<[^>]*>/g, '') // Remove HTML tags
-      .replace(/\s+/g, ' ')
-      .trim();
+  private static async extractPdfContent(url: string): Promise<{
+    title: string;
+    content: string;
+    type: string;
+  }> {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+      const arrayBuffer = await res.arrayBuffer();
+      const data = await pdfParse(Buffer.from(arrayBuffer));
+      const title = (data.info && (data.info as any).Title) || url.split("/").pop() || "PDF Document";
+      const content = data.text.trim();
+      return { title, content, type: "pdf" };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      throw new Error(`PDF extraction failed: ${errorMessage}`);
+    }
   }
 
   private static async extractWebContent(url: string): Promise<{
@@ -134,7 +111,7 @@ export class ContentExtractor {
     try {
       const response = await fetch(url, {
         headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
         }
       });
 
@@ -143,30 +120,23 @@ export class ContentExtractor {
       }
 
       const html = await response.text();
-      
-      // Extract title
       const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-      const title = titleMatch ? titleMatch[1].trim() : 'Web Page';
+      const title = titleMatch ? titleMatch[1].trim() : "Web Page";
 
-      // Basic content extraction (remove HTML tags and get text)
       const content = html
-        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-        .replace(/<[^>]*>/g, ' ')
-        .replace(/\s+/g, ' ')
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+        .replace(/<[^>]*>/g, " ")
+        .replace(/\s+/g, " ")
         .trim();
 
-      // Take first 10000 characters to avoid too much content
-      const trimmedContent = content.length > 10000 ? content.substring(0, 10000) + '...' : content;
+      const trimmedContent = content.length > 10000 ? content.substring(0, 10000) + "..." : content;
 
-      return {
-        title,
-        content: trimmedContent,
-        type: 'webpage'
-      };
+      return { title, content: trimmedContent, type: "webpage" };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`Web content extraction failed: ${errorMessage}`);
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- use `youtube-transcript` for YouTube handling and drop external `yt-dlp` dependency
- add PDF content extraction via `pdf-parse`
- document new packages in dependencies

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68bda77bb28c832e935decdff68134da